### PR TITLE
Extra BSD structures supported. Slight improvements on error handling.

### DIFF
--- a/.github/workflows/generate_RTD.yml
+++ b/.github/workflows/generate_RTD.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-RTD:
-    name: Update the ReadTheDocs documentation if README has been modified
+    name: Update the ReadTheDocs documentation if README or notebooks have been modified
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +23,9 @@ jobs:
         run: |
           cp README.md docs/README.md
           sed -i 's/`mermaid/`\{mermaid\}/g' docs/README.md
+      - name: copy notebooks
+        run: |
+          cp -r examples/notebooks docs/notebooks
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Updating docs"

--- a/biobroker/api/README.md
+++ b/biobroker/api/README.md
@@ -6,5 +6,6 @@
 
 
 ## TO-DO list
+
 - Additional errors needed:
   - Requests that get a 400 (e.g. Trying to update samples not owned by the user)

--- a/biobroker/api/README.md
+++ b/biobroker/api/README.md
@@ -6,10 +6,5 @@
 
 
 ## TO-DO list
-- BsdApi: Add support for structured data
-  - Add method `add_structured_data`
-  - Add method `remove_structured_data`
-  - Add method `get_structured_data`
-  - Add method `get_structured_data_by_type`
 - Additional errors needed:
   - Requests that get a 400 (e.g. Trying to update samples not owned by the user)

--- a/biobroker/api/api.py
+++ b/biobroker/api/api.py
@@ -374,7 +374,7 @@ class BsdApi(GenericApi):
             raise StructuredDataError(logger=self.logger, errors=errors)
 
         if not all([mandatory_key in structured_data for mandatory_key in ("data", "accession")]):
-            errors.append(f"Structured data MUST contain 'data' and 'accession' in root")
+            errors.append("Structured data MUST contain 'data' and 'accession' in root")
         if not Biosample.check_accession(structured_data['accession']):
             errors.append("Structured data MUST point to a valid accession")
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,4 @@ README
     :titlesonly:
     :caption: Notebooks
 
-    notebooks/1.full_example_submission_biosamples/submit_to_biosamples_no_validation
-    notebooks/2.example_validation_biosamples/submit_to_biosamples_validating
-    notebooks/3.modify_input_with_map/modifying_source_input
-    notebooks/4.retrieving_samples/retrieving_samples
-    notebooks/5.updating_samples/updating_submitted_samples
+    notebooks/**/*

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -8,6 +8,8 @@ This folder contains a set of python notebooks to show usage of the `biobroker` 
 3. How to modify your input source metadata before submission
 4. How to retrieve samples after submission
 5. How to update the samples
+6. How to submit complex metadata
 
-It is not necessary to view them in this order; However, it is *highly recommended*.
+It is not necessary to view them in this order; However, it is *highly recommended*. One of the reasons it is recommended
+is because... well, example number 1 contains instructions on library install. Follow at your _own risk_!
 

--- a/to-do.md
+++ b/to-do.md
@@ -2,7 +2,6 @@
     - Improve on submit error reporting
         - Current known bug for BSDAPI: submit_multiple currently batches submit requests. If first batch succeeds but second
           fails, it will submit the first batch and error out, returning naaaaaathing.
-- Create examples - Via python notebooks
 - Create pytests
 - Create a `viewer`
     - Simple interface, loads filled out metadata entities


### PR DESCRIPTION
## GH actions

Now pushing notebooks to documentation. 

## Documentation


- One to do less in API!
- Updated notebook README with a notebook I am working on. Had to stash the change and applied automatically, so.. notebook coming soon! (Notebook needs v0.5 of this library to work, which is going to be released with this PR)
- `index.rst` loads all notebooks through wildcards

# Source code

## API

### BsdApi
- 3 new exceptions created. One for annoying no error message errors, 2 for structured data.
- Added structured data submission support, including pre-submission validation
- I think BSD changed the structure of their responses for errors, so... added a bit more handling. I am not sure so I am not deleting the old try-catches, but for now this should work.
- Added support for external references. For now they are not validated, so I have added as a to-do to further test and validate the responses.
- Forcing data release format. I was having issues reading from some inputs (Damn you excel), so now I have added a parser from dateutils that should help to convert formats to the proper, expected ISO format.