### PR TITLE
Relationships more flexible. Now validates for organism

### DIFF
--- a/biobroker/api/api.py
+++ b/biobroker/api/api.py
@@ -1,4 +1,6 @@
 import os
+from re import split
+
 import requests
 
 from os.path import join
@@ -288,8 +290,10 @@ class BsdApi(GenericApi):
             for relationship_type in self.relationship_types:
                 if relationship_type in entity:
                     for split_relationship_value in entity[relationship_type]['text'].split(entity.delimiter):
+                        target = split_relationship_value if Biosample.check_accession(split_relationship_value) \
+                            else id_to_accession[split_relationship_value]
                         entity.add_relationship(source=entity.accession,
-                                                target=id_to_accession[split_relationship_value],
+                                                target=target,
                                                 relationship=relationship_type)
                     del entity[relationship_type]
         updated_entities = self.update(entities)

--- a/biobroker/api/api.py
+++ b/biobroker/api/api.py
@@ -1,5 +1,4 @@
 import os
-from re import split
 
 import requests
 

--- a/biobroker/metadata_entity/exceptions.py
+++ b/biobroker/metadata_entity/exceptions.py
@@ -33,3 +33,9 @@ class RelationshipInvalidTargetError(Exception):
                         "used")
         logger.error(self.message)
         super().__init__(self.message)
+
+class NoOrganismSetError(Exception):
+    def __init__(self, logger: logging.Logger, sample_id: str):
+        self.message = f"Property 'organism' (Or any variant) needs to be set-up for the sample '{sample_id}'"
+        logger.error(self.message)
+        super().__init__(self.message)

--- a/biobroker/metadata_entity/metadata_entity.py
+++ b/biobroker/metadata_entity/metadata_entity.py
@@ -6,7 +6,7 @@ from dateutil import parser
 from typing import Any
 
 from biobroker.metadata_entity.exceptions import NoNameSetError, NameShouldBeStringError, RelationshipInvalidSourceError, \
-    RelationshipInvalidTargetError
+    RelationshipInvalidTargetError, NoOrganismSetError
 from biobroker.generic.exceptions import MandatoryFunctionNotSet
 from biobroker.generic.logger import set_up_logger
 
@@ -184,6 +184,7 @@ class Biosample(GenericEntity):
         """
         self._check_name()
         self._check_release_date()
+        self._check_organism()
 
     def flatten(self) -> dict:
         """
@@ -314,6 +315,15 @@ class Biosample(GenericEntity):
             self['release'] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         else:
             self['release'] = parser.isoparse(self['release']).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    def _check_organism(self):
+        """
+        Check that the organism is set.
+
+        :raises:`~biobroker.metadata_entity.exceptions.NoOrganismSetError`
+        """
+        if not any([organism_property in self for organism_property in ('organism', 'Organism', 'species', 'Species')]):
+            raise NoOrganismSetError
 
 
     def add_relationship(self, source, target, relationship):


### PR DESCRIPTION
# Source code

## API

### BsdApi
- `process_relationships` now takes sample accessions as well. No longer need to trigger updates manually!

## Metadata entity

### BioSample
- Now checks for `organism`, `Organism`, `species` or `Species` to be set up