### PR TITLE
Fixed structured data return. Fixed multiple input relationships. Fixed multiple URLs.

### DIFF
--- a/biobroker/api/api.py
+++ b/biobroker/api/api.py
@@ -336,7 +336,7 @@ class BsdApi(GenericApi):
 
         return [Biosample(sample) for sample in samples]
 
-    def submit_structured_data(self, structured_data: dict) -> Biosample:
+    def submit_structured_data(self, structured_data: dict) -> list[Biosample]:
         """
         Submit structured data to a sample in BioSamples. The data is checked before submission. May raise:
         - :exc:`~biobroker.api.exceptions.StructuredDataError`: Pre-submission errors
@@ -349,7 +349,7 @@ class BsdApi(GenericApi):
         structured_data_put_uri = join(self.structured_data_endpoint, structured_data['accession'])
         response = self.authenticator.put(url=structured_data_put_uri, payload=structured_data)
         if response.status_code == 200:
-            return Biosample(response.json())
+            return self.retrieve([structured_data['accession']])
         raise StructuredDataSubmissionError(self.logger, response)
 
 

--- a/biobroker/metadata_entity/README.md
+++ b/biobroker/metadata_entity/README.md
@@ -22,3 +22,4 @@ BsdApi:
   a batch submission, but that may make the process way slower. Need to test speed for that.
 - Add the missing relationship types, don't be lazy
 - Add a way to delete the samples (empty put, basically)
+- **KNOWN BUG**: Multiple relationships may not be added correctly with '__setitem__'

--- a/biobroker/metadata_entity/README.md
+++ b/biobroker/metadata_entity/README.md
@@ -23,3 +23,4 @@ BsdApi:
 - Add the missing relationship types, don't be lazy
 - Add a way to delete the samples (empty put, basically)
 - **KNOWN BUG**: Multiple relationships may not be added correctly with '__setitem__'
+- **KNOWN BUG**: The order of the factors does alter the product. Accession needs to be set-up first in order for some of the '__setitem__' checks to go through correctly. Whoopsie.

--- a/biobroker/metadata_entity/metadata_entity.py
+++ b/biobroker/metadata_entity/metadata_entity.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import re
-from venv import logger
 
 from dateutil import parser
 from typing import Any

--- a/biobroker/metadata_entity/metadata_entity.py
+++ b/biobroker/metadata_entity/metadata_entity.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import re
+from venv import logger
 
 from dateutil import parser
 from typing import Any
@@ -261,13 +262,16 @@ class Biosample(GenericEntity):
         if key in Biosample.ROOT_PROPERTIES:
             self.entity[key] = value
         # Relationships
-        elif self.accession and key in Biosample.VALID_RELATIONSHIPS and self.check_accession(value):
-            self.add_relationship(source=self.accession,
-                                  target=value,
-                                  relationship=key)
+        elif self.accession and key in Biosample.VALID_RELATIONSHIPS and all([
+            self.check_accession(accession) for accession in value.split(self.delimiter)]):
+            for target in value.split(self.delimiter):
+                self.add_relationship(source=self.accession,
+                                      target=target,
+                                      relationship=key)
         # External references
         elif key == Biosample.EXTERNAL_REFERENCE_FIELD:
-            self.add_external_reference(value)
+            for url in value.split(self.delimiter):
+                self.add_external_reference(url=url)
         # characteristics
         else:
             characteristic = {}
@@ -323,7 +327,7 @@ class Biosample(GenericEntity):
         :raises:`~biobroker.metadata_entity.exceptions.NoOrganismSetError`
         """
         if not any([organism_property in self for organism_property in ('organism', 'Organism', 'species', 'Species')]):
-            raise NoOrganismSetError
+            raise NoOrganismSetError(logger=self.logger, sample_id=self.id)
 
 
     def add_relationship(self, source, target, relationship):


### PR DESCRIPTION
# Documentation
- Added 2 new bugs T_T I'll fix them eventually I swear

# Source code

## API

### BsdApi
- Method `submit_structured_data` now properly returns a sample (The structured data POST request returns the structured data itself if successful; I prefer to return the whole sample with the structured data)

## Metadata entity

### Biosample

- Fixed some actions in `__setitem__`:
   - Multiple `relationships` coming from the same type (e.g. 'derived_from') are now processed. Due to an oversight before, they weren't being considered
   - Multiple external relationships (aka, urls) are accepted. Same-ish oversight as before
- Fixed `NoOrganismSetError`: I forgoR to raise it properly