### PR TITLE
Fixed __setitem__ to properly handle ontology terms

### DIFF
--- a/biobroker/metadata_entity/metadata_entity.py
+++ b/biobroker/metadata_entity/metadata_entity.py
@@ -282,7 +282,8 @@ class Biosample(GenericEntity):
                     self.logger.warning(f"Tag '{tag_name}' on property '{key}' is not a documented valid tag. "
                                         "It may be rejected on submission.")
                 characteristic = self.entity['characteristics'].get(key, [{}])[0]
-                characteristic[tag_name] = value
+                # Kinda hate to have soooo many ifs, but every field has its own rules...
+                characteristic[tag_name] = value if tag_name != 'ontologyTerms' else value.split(self.delimiter)
             else:
                 characteristic['text'] = value
 


### PR DESCRIPTION
# Source code

## Metadata entity

### Biosample
- Fixed `__setitem__` when handling tags; `ontologyTerms` is an array

<!--
Please uncomment as needed:


## API

## Authenticator

## Generic

## Input processor



## Output processor

## Wrangler

# Documentation

# Examples

## Notebooks

## Scripts

# Other
(Include here anything not related to the above e.g. a new workflow stablished)
-->